### PR TITLE
hotfix for the case of "Optimize_hard_drive == T"

### DIFF
--- a/rules/Round2.smk
+++ b/rules/Round2.smk
@@ -68,9 +68,9 @@ rule download_fastq2:
         "download/{sample}.download.sh",
         "Round2/TOTAL.ME_centric.txt"
     params:
-        "FASTQ/{sample}.fastq"
+        "FASTQ/{sample}.fastq.gz"
     output:
-        temp("FASTQ/round2/{sample}.fastq")
+        temp("FASTQ/round2/{sample}.fastq.gz")
     priority: -10
     resources: 
         get_data = 1


### PR DESCRIPTION
This hotfix should be able to fix the error mentioned in #27 ,
which occurs an "MissingInputException" when setting the value of "Optimize_hard_drive" to "T".